### PR TITLE
Added `subFactorial()` method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
     "riimu/kit-baseconversion": "^1",
     "samsara/common": "^1",
     "php-ds/php-ds": "^1.1",
-    "php": ">=8.0"
+    "php": ">=8.0",
+    "ext-bcmath": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.*",
-    "scrutinizer/ocular": "*"
+    "phpunit/phpunit": "9.*"
   },
   "suggest": {
     "ext-gmp": "*",

--- a/src/Samsara/Fermat/Types/Base/Interfaces/Numbers/DecimalInterface.php
+++ b/src/Samsara/Fermat/Types/Base/Interfaces/Numbers/DecimalInterface.php
@@ -84,6 +84,11 @@ interface DecimalInterface extends SimpleNumberInterface
     /**
      * @return DecimalInterface
      */
+    public function subFactorial(): DecimalInterface;
+
+    /**
+     * @return DecimalInterface
+     */
     public function doubleFactorial(): DecimalInterface;
 
     /**

--- a/src/Samsara/Fermat/Types/Traits/IntegerMathTrait.php
+++ b/src/Samsara/Fermat/Types/Traits/IntegerMathTrait.php
@@ -49,6 +49,41 @@ trait IntegerMathTrait
 
     }
 
+    /**
+     * @return DecimalInterface
+     * @throws IncompatibleObjectState
+     * @throws IntegrityConstraint
+     */
+    public function subFactorial(): DecimalInterface
+    {
+        if ($this->isLessThan(1)) {
+            if ($this->isEqual(0)) {
+                return $this->setValue(1);
+            }
+            throw new IncompatibleObjectState(
+                'Can only perform a sub-factorial on a non-negative number.',
+                'Ensure that the number is not negative before calling subFactorial().',
+                'The subFactorial() method was called on a value that was negative.'
+            );
+        }
+
+        if (!$this->isInt()) {
+            throw new IncompatibleObjectState(
+                'Can only perform a sub-factorial on a whole number.',
+                'Ensure that the number does not have any fractional value before calling subFactorial().',
+                'The subFactorial() method was called on a value that was not a whole number.'
+            );
+        }
+
+        $e = Numbers::makeE($this->getScale());
+        $num = new ImmutableDecimal($this->getValue(10));
+
+        $num = $num->factorial();
+        $num = $num->divide($e, 3)->add('0.5');
+
+        return $num->floor();
+    }
+
     public function doubleFactorial(): DecimalInterface
     {
         if ($this->isWhole() && $this->isLessThanOrEqualTo(1)) {

--- a/tests/Samsara/Fermat/Values/ImmutableDecimalTest.php
+++ b/tests/Samsara/Fermat/Values/ImmutableDecimalTest.php
@@ -181,22 +181,78 @@ class ImmutableDecimalTest extends TestCase
 
         $this->assertEquals('6', $three->factorial()->getValue());
         $this->assertEquals('120', $five->factorial()->getValue());
+    }
 
+    /**
+     * @small
+     */
+    public function testFactorialExceptionsOne()
+    {
         $negativeOne = new ImmutableDecimal(-1);
 
         $this->expectException(IncompatibleObjectState::class);
         $this->expectExceptionMessage('Can only perform a factorial on a non-negative number.');
 
         $negativeOne->factorial();
+    }
 
+    /**
+     * @small
+     */
+    public function testFactorialExceptionsTwo()
+    {
         $oneTenth = new ImmutableDecimal('1.1');
 
         $this->expectException(IncompatibleObjectState::class);
         $this->expectExceptionMessage('Can only perform a factorial on a whole number');
 
         $oneTenth->factorial();
-
     }
+
+    /**
+     * @medium
+     */
+    public function testSubFactorial()
+    {
+        $num = new ImmutableDecimal('4');
+
+        $this->assertEquals('9', $num->subFactorial()->getValue());
+
+        $num2 = new ImmutableDecimal('7');
+
+        $this->assertEquals('1854', $num2->subFactorial()->getValue());
+
+        $num3 = new ImmutableDecimal(0);
+
+        $this->assertEquals('1', $num3->subFactorial()->getValue());
+    }
+
+    /**
+     * @small
+     */
+    public function testSubFactorialExceptionsOne()
+    {
+        $negativeOne = new ImmutableDecimal(-1);
+
+        $this->expectException(IncompatibleObjectState::class);
+        $this->expectExceptionMessage('Can only perform a sub-factorial on a non-negative number.');
+
+        $negativeOne->subFactorial();
+    }
+
+    /**
+     * @small
+     */
+    public function testSubFactorialExceptionsTwo()
+    {
+        $oneTenth = new ImmutableDecimal('1.1');
+
+        $this->expectException(IncompatibleObjectState::class);
+        $this->expectExceptionMessage('Can only perform a sub-factorial on a whole number');
+
+        $oneTenth->subFactorial();
+    }
+
     /**
      * @medium
      */


### PR DESCRIPTION
[closes #95]

- Added the `subFactorial()` method to `IntegerMathTrait`, along with corresponding tests to `ImmutableDecimalTest`.
- Updated composer.json to put `ext-bcmath` back in. It's installed by default, but not included in core.
- Fixed a test for `factorial()` dealing with one of the exceptions