### PR TITLE
Added `RoundingProvider` and New Rounding Modes

### DIFF
--- a/docs/getting-started/rounding-modes.md
+++ b/docs/getting-started/rounding-modes.md
@@ -1,25 +1,312 @@
-# Available Modes
+# Rounding Modes
 
-This page is about a planned feature for Fermat that is not yet implemented, but will be included in the next release.
+Rounding in Fermat is accomplished by making calls to the `RoundingProvider`. This provider accepts a `DecimalInterface` as its input, and provides the rounded value as a string. The rounding provider provides two broad types of rounding, deterministic and non-deterministic (or semi-deterministic).
+
+!!! note "Rounding is Anything that Reduces Scale"
+    Many people think of rounding as selecting the closest integer to a given number, with some kind of rule for what to do when you are half-way between two integers. However, rounding broadly covers any action that reduces the scale or precision of a number. Going from more digits to fewer digits is rounding regardless of how it is done.
+
+    This means that even operations like `truncate()` or `floor()` or `ceil()` are rounding. Since truncate is better handled by the `Decimal` object itself, due to its knowledge of the internal state of the object, that is not handled by the `RoundingProvider`. All other kinds of rounding offered in Fermat utilize the `RoundingProvider` however.
+
+    For this reason it is designed to be as lightweight as possible while still accomplishing its task.
+
+The random provider has a private static property where it stores the mode to use while rounding. This property can be read and set using public static methods, but as it is a static property it affects all rounding operations after a mode is changed, even those you don't directly call. This is useful in most cases, since it allows you to set the rounding mode once at the beginning of your program and then utilize that rounding mode in every call that is made to the library.
+
+The default mode is `RandomProvider::MODE_HALF_EVEN`. This is also the fallback mode if you ask for a non-existent rounding mode.
+
+!!! caution "Rounding Mode Affects Many Operations Internally"
+    Rounding occurs frequently in Fermat, since many operations produce more digits than the scale setting of your objects. The trigonometry functions, logarithmic function, and exponential functions all make a call to the `RoundingProvider` before returning a result. This means that selecting a rounding mode will affect the results you get from functions such as `tan()`, `sin()`, `exp()`, and `ln()`.
+
+    In most cases this is not an issue, and would even be preferred to keep your results consistent with the other effects of rounding within the library. However, some modes such as Stochastic may produce results that are more inconsistent with the expectations of your program. 
+
+    If you want to manually round an object once using a different mode, pass the mode as an argument to the `round()` method on your `Decimal` object instead of setting a new default more in the `RoundingProvider`. When done in this way, the provided mode will only be used for that one operation without affecting the default more for any other operations.
+
+!!! see-also "See Also"
+    The exact signatures associated with the `RandomProvider` can be found in the [Rounding Provider Reference Page](../reference/providers/rounding.md)
 
 ## Available Modes
 
-###### Selectable::ROUND_MODE_TRUNCATE = 10
+!!! caution "Rounding Is Base-10 Referenced"
+    As noted in other places, anything related to scale in this library is specific to base-10. While you can still round in other bases, the operations will be performed on the base-10 representation of the number instead of the base the `Decimal` object is in.
 
-###### Selectable::ROUND_MODE_UP = 11
+### Half Up
 
-###### Selectable::ROUND_MODE_DOWN = 12
+This rounding mode rounds the number towards positive infinity when halfway between two values.
 
-###### Selectable::ROUND_MODE_CEILING = 13
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Up" mode:
 
-###### Selectable::ROUND_MODE_FLOOR = 14
+        `1.5 -> 2`
 
-###### Selectable::ROUND_MODE_HALF_UP = 15
+    === "-1.5"
+        Using the "Half Up" mode:
 
-###### Selectable::ROUND_MODE_HALF_DOWN = 16
+        `-1.5 -> -1`
 
-###### Selectable::ROUND_MODE_HALF_EVEN = 17
+    === "2.5"
+        Using the "Half Up" mode:
 
-###### Selectable::ROUND_MODE_HALF_ODD = 18
+        `2.5 -> 3`
 
-###### Selectable::ROUND_MODE_HALF_RAND = 19
+    === "-2.5"
+        Using the "Half Up" mode:
+
+        `-2.5 -> -2`
+
+### Half Down
+
+This rounding mode rounds the number towards negative infinity when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Down" mode:
+    
+        `1.5 -> 1`
+
+    === "-1.5"
+        Using the "Half Down" mode:
+
+        `-1.5 -> -2`
+
+    === "2.5"
+        Using the "Half Down" mode:
+
+        `2.5 -> 2`
+
+    === "-2.5"
+        Using the "Half Down" mode:
+
+        `-2.5 -> -3`
+
+### Half Even
+
+This rounding mode rounds the number towards the nearest even number when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Even" mode:
+
+        `1.5 -> 2`
+
+    === "-1.5"
+        Using the "Half Even" mode:
+
+        `-1.5 -> -2`
+
+    === "2.5"
+        Using the "Half Even" mode:
+
+        `2.5 -> 2`
+
+    === "-2.5"
+        Using the "Half Even" mode:
+
+        `-2.5 -> -2`
+
+### Half Odd
+
+This rounding mode rounds the number towards the nearest odd number when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Odd" mode:
+
+        `1.5 -> 1`
+
+    === "-1.5"
+        Using the "Half Odd" mode:
+
+        `-1.5 -> -1`
+
+    === "2.5"
+        Using the "Half Odd" mode:
+
+        `2.5 -> 3`
+
+    === "-2.5"
+        Using the "Half Odd" mode:
+
+        `-2.5 -> -3`
+
+### Half Zero
+
+This rounding mode rounds the number towards zero when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Zero" mode:
+
+        `1.5 -> 1`
+
+    === "-1.5"
+        Using the "Half Zero" mode:
+
+        `-1.5 -> -1`
+
+    === "2.5"
+        Using the "Half Zero" mode:
+
+        `2.5 -> 2`
+
+    === "-2.5"
+        Using the "Half Zero" mode:
+
+        `-2.5 -> -2`
+
+### Half Infinity
+
+This rounding mode rounds the number towards the nearest infinity (positive or negative) when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Half Infinity" mode:
+
+        `1.5 -> 2`
+
+    === "-1.5"
+        Using the "Half Infinity" mode:
+
+        `-1.5 -> -2`
+
+    === "2.5"
+        Using the "Half Infinity" mode:
+
+        `2.5 -> 3`
+
+    === "-2.5"
+        Using the "Half Infinity" mode:
+
+        `-2.5 -> -3`
+
+### Ceil
+
+This rounding mode rounds the number towards positive infinity, even for values which are not halfway between.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Ceil" mode:
+
+        `1.5 -> 2`
+
+    === "-1.5"
+        Using the "Ceil" mode:
+
+        `-1.5 -> -1`
+
+    === "2.2"
+        Using the "Ceil" mode:
+
+        `2.2 -> 3`
+
+    === "-2.2"
+        Using the "Ceil" mode:
+
+        `-2.2 -> -2`
+
+### Floor
+
+This rounding mode rounds the number towards negative infinity, even for values which are not halfway between.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Floor" mode:
+
+        `1.5 -> 1`
+
+    === "-1.5"
+        Using the "Floor" mode:
+
+        `-1.5 -> -2`
+
+    === "2.2"
+        Using the "Floor" mode:
+
+        `2.2 -> 2`
+
+    === "-2.2"
+        Using the "Floor" mode:
+
+        `-2.2 -> -3`
+
+### Random
+
+This rounding mode rounds the number in a direction that is randomly chosen when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Random" mode:
+
+        `1.5 -> 1` 50% of the time
+        `1.5 -> 2` 50% of the time
+
+    === "1.7"
+        Using the "Random" mode:
+
+        `1.7 -> 2` 100% of the time
+
+    === "2.2"
+        Using the "Random" mode:
+
+        `2.2 -> 2` 100% of the time
+
+    === "-2.5"
+        Using the "Random" mode:
+
+        `-2.5 -> -2` 50% of the time
+        `-2.5 -> -3` 50% of the time
+
+### Alternating
+
+This rounding mode rounds the number in a direction that alternates as more calls to `round()` are made when halfway between two values.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Alternating" mode:
+
+        `1.5 -> 2` on the first call
+        `1.5 -> 1` on the second call
+
+    === "1.7"
+        Using the "Alternating" mode:
+
+        `1.7 -> 2` 100% of the time
+
+    === "2.2"
+        Using the "Alternating" mode:
+
+        `2.2 -> 2` 100% of the time
+
+    === "-2.5"
+        Using the "Alternating" mode:
+
+        `-2.5 -> -3` on the first call
+        `-2.5 -> -2` on the second call
+
+### Stochastic
+
+This rounding mode rounds the number in both directions in proportion to how close it is to both values. This occurs regardless of whether the number is halfway between. Please see the examples below for clarification.
+
+!!! example "Examples"
+    === "1.5"
+        Using the "Stochastic" mode:
+
+        `1.5 -> 2` 50% of the time
+        `1.5 -> 1` 50% of the time
+
+    === "1.7"
+        Using the "Stochastic" mode:
+
+        `1.7 -> 2` 70% of the time
+        `1.7 -> 1` 30% of the time
+
+    === "2.2"
+        Using the "Stochastic" mode:
+
+        `2.2 -> 3` 20% of the time
+        `2.2 -> 2` 80% of the time
+
+    === "-2.5"
+        Using the "Stochastic" mode:
+
+        `-2.5 -> -3` 50% of the time
+        `-2.5 -> -2` 50% of the time

--- a/docs/reference/providers/rounding.md
+++ b/docs/reference/providers/rounding.md
@@ -1,0 +1,109 @@
+# The Rounding Provider
+
+The rounding provider allows you to round a number of arbitrary precision and scale using one of several rounding modes.
+
+### Available Constants
+
+The following constants are available on the `RoundProvider` class.
+
+!!! signature constant "RoundingProvider::MODE_HALF_UP"
+    type
+    :   integer
+
+    value
+    :   1
+
+!!! signature constant "RoundingProvider::MODE_HALF_DOWN"
+    type
+    :   integer
+
+    value
+    :   2
+
+!!! signature constant "RoundingProvider::MODE_HALF_EVEN"
+    type
+    :   integer
+
+    value
+    :   3
+
+!!! signature constant "RoundingProvider::MODE_HALF_ODD"
+    type
+    :   integer
+
+    value
+    :   4
+
+!!! signature constant "RoundingProvider::MODE_HALF_ZERO"
+    type
+    :   integer
+
+    value
+    :   5
+
+!!! signature constant "RoundingProvider::MODE_HALF_INF"
+    type
+    :   integer
+
+    value
+    :   6
+
+!!! signature constant "RoundingProvider::MODE_CEIL"
+    type
+    :   integer
+
+    value
+    :   7
+
+!!! signature constant "RoundingProvider::MODE_FLOOR"
+    type
+    :   integer
+
+    value
+    :   8
+
+!!! signature constant "RoundingProvider::MODE_RANDOM"
+    type
+    :   integer
+
+    value
+    :   9
+
+!!! signature constant "RoundingProvider::MODE_ALTERNATING"
+    type
+    :   integer
+
+    value
+    :   10
+
+!!! signature constant "RoundingProvider::MODE_STOCHASTIC"
+    type
+    :   integer
+
+    value
+    :   11
+
+### Available Public Static Methods
+
+The following public static methods are available on the `RoundingProvider` class.
+
+!!! signature "RoundingProvider::round(DecimalInterface $decimal, int $places = 0)"
+    $decimal
+    :   The number being rounded. It must be an instance of a class that implements `DecimalInterface`.
+
+    $places
+    :   The number of places after the decimal to begin rounding. For rounding to the nearest integer, provide zero for this parameter. To round to the nearest hundred you would provide -2.
+    
+    return
+    :   The string of the rounded number
+
+!!! signature "RoundingProvider::getRoundingMode()"
+    return
+    :   The integer corresponding to the current rounding mode. This can be compared to the class constants.
+
+!!! signature "RoundingProvider::setRoundingMode(int $mode)"
+    $mode
+    :   The mode flag to use in future rounding calls. Intended to be used in conjunction with the class constants.
+
+    return
+    :   void

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
           - 'Arithmetic': 'reference/providers/arithmetic.md'
           - 'Constant': 'reference/providers/constant.md'
           - 'Polyfill': 'reference/providers/polyfill.md'
+          - 'Rounding': 'reference/providers/rounding.md'
           - 'Sequence': 'reference/providers/sequence.md'
           - 'Series': 'reference/providers/series.md'
           - 'Stats': 'reference/providers/stats.md'

--- a/src/Samsara/Fermat/Numbers.php
+++ b/src/Samsara/Fermat/Numbers.php
@@ -158,9 +158,9 @@ class Numbers
         }
 
         /** @var ImmutableDecimal $numerator */
-        $numerator = self::make(self::IMMUTABLE, trim(ltrim($parts[0])))->round();
+        $numerator = self::make(self::IMMUTABLE, trim(ltrim($parts[0])));
         /** @var ImmutableDecimal $denominator */
-        $denominator = isset($parts[1]) ? self::make(self::IMMUTABLE, trim(ltrim($parts[1])))->round() : self::makeOne();
+        $denominator = isset($parts[1]) ? self::make(self::IMMUTABLE, trim(ltrim($parts[1]))) : self::makeOne();
 
         if ($type === self::IMMUTABLE_FRACTION) {
             return new ImmutableFraction($numerator, $denominator, $base);

--- a/src/Samsara/Fermat/Provider/RoundingProvider.php
+++ b/src/Samsara/Fermat/Provider/RoundingProvider.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Samsara\Fermat\Provider;
+
+use JetBrains\PhpStorm\ExpectedValues;
+use JetBrains\PhpStorm\Pure;
+use Samsara\Fermat\Types\Base\Interfaces\Numbers\DecimalInterface;
+
+class RoundingProvider
+{
+
+    const MODE_HALF_UP = 1;
+    const MODE_HALF_DOWN = 2;
+    const MODE_HALF_EVEN = 3;
+    const MODE_HALF_ODD = 4;
+    const MODE_HALF_ZERO = 5;
+    const MODE_HALF_INF = 6;
+    const MODE_CEIL = 7;
+    const MODE_FLOOR = 8;
+    const MODE_RANDOM = 9;
+    const MODE_ALTERNATING = 10;
+    const MODE_STOCHASTIC = 11;
+
+    private static int $mode = self::MODE_HALF_EVEN;
+    private static ?DecimalInterface $decimal;
+    private static int $alt = 1;
+    private static ?string $remainder;
+
+    public static function setRoundingMode(
+        #[ExpectedValues([
+            self::MODE_HALF_UP,
+            self::MODE_HALF_DOWN,
+            self::MODE_HALF_EVEN,
+            self::MODE_HALF_ODD,
+            self::MODE_HALF_ZERO,
+            self::MODE_HALF_INF,
+            self::MODE_CEIL,
+            self::MODE_FLOOR,
+            self::MODE_RANDOM,
+            self::MODE_ALTERNATING,
+            self::MODE_STOCHASTIC
+        ])]
+        int $mode
+    ): void
+    {
+        static::$mode = $mode;
+    }
+
+    #[Pure]
+    public static function getRoundingMode(): int
+    {
+        return static::$mode;
+    }
+
+    public static function round(DecimalInterface $decimal, int $places = 0): string
+    {
+        static::$decimal = $decimal;
+
+        $rawString = str_replace('-', '', $decimal->getAsBaseTenRealNumber());
+
+        if ($decimal->isInt() && $places >= 0) {
+            return $rawString;
+        }
+
+        $sign = $decimal->isNegative() ? '-' : '';
+        $imaginary = $decimal->isImaginary() ? 'i' : '';
+
+        if (str_contains($rawString, '.')) {
+            [$wholePart, $decimalPart] = explode('.', $rawString);
+        } else {
+            $wholePart = $rawString;
+            $decimalPart = '';
+        }
+
+        $absPlaces = abs($places);
+
+        $currentPart = $places >= 0;
+        $roundedPart = $currentPart ? str_split($decimalPart) : str_split($wholePart);
+        $roundedPartString = $currentPart ? $decimalPart : $wholePart;
+        $otherPart = $currentPart ? str_split($wholePart) : str_split($decimalPart);
+        $baseLength = $currentPart ? strlen($decimalPart)-1 : strlen($wholePart);
+        $pos = $currentPart ? $places : $baseLength + $places;
+        $carry = 0;
+
+        if ($currentPart) {
+            $pos = ($absPlaces > $baseLength) ? $baseLength : $pos;
+        } else {
+            $pos = ($absPlaces >= $baseLength) ? 0 : $pos;
+        }
+
+        do {
+            if (!array_key_exists($pos, $roundedPart)) {
+                break;
+            }
+
+            $digit = (int)$roundedPart[$pos] + $carry;
+
+            if ($carry == 0 && $digit == 5) {
+                static::$remainder = substr($roundedPartString, $pos+1);
+            } else {
+                static::$remainder = null;
+            }
+
+            if ($pos == 0) {
+                if ($currentPart) {
+                    $nextDigit = (int)$otherPart[count($otherPart)-1];
+                } else {
+                    $nextDigit = 0;
+                }
+            } else {
+                $nextDigit = (int)$roundedPart[$pos-1];
+            }
+
+            if ($carry == 0) {
+                $carry = match (self::getRoundingMode()) {
+                    self::MODE_HALF_UP => self::roundHalfUp($digit),
+                    self::MODE_HALF_DOWN => self::roundHalfDown($digit),
+                    self::MODE_HALF_ODD => self::roundHalfOdd($digit, $nextDigit),
+                    self::MODE_HALF_ZERO => self::roundHalfZero($digit),
+                    self::MODE_HALF_INF => self::roundHalfInf($digit),
+                    self::MODE_CEIL => self::roundCeil($digit),
+                    self::MODE_FLOOR => self::roundFloor(),
+                    self::MODE_RANDOM => self::roundRandom($digit),
+                    self::MODE_ALTERNATING => self::roundAlternating($digit),
+                    self::MODE_STOCHASTIC => self::roundStochastic($digit),
+                    default => self::roundHalfEven($digit, $nextDigit)
+                };
+            } else {
+                if ($digit > 9) {
+                    $carry = 1;
+                    $roundedPart[$pos] = '0';
+                } else {
+                    $carry = 0;
+                    $roundedPart[$pos] = $digit;
+                }
+            }
+
+            if ($pos == 0 && $carry == 1) {
+                if ($currentPart) {
+                    $currentPart = false;
+
+                    // Do the variable swap dance
+                    $temp = $otherPart;
+                    $otherPart = $roundedPart;
+                    $roundedPart = $temp;
+
+                    $pos = count($roundedPart)-1;
+                } else {
+                    array_unshift($roundedPart, $carry);
+                    $carry = 0;
+                }
+            } else {
+                $pos -= 1;
+            }
+        } while ($carry == 1);
+
+        if ($currentPart) {
+            $newDecimalPart = implode('', $roundedPart);
+            $newWholePart = implode('', $otherPart);
+        } else {
+            $newDecimalPart = implode('', $otherPart);
+            $newWholePart = implode('', $roundedPart);
+        }
+
+        if ($places > 0) {
+            $newDecimalPart = substr($newDecimalPart, 0, $places);
+        } elseif ($places == 0) {
+            $newDecimalPart = '0';
+        } else {
+            $newWholePart = substr($newWholePart, 0, strlen($wholePart)+$places).str_repeat('0', $places*-1);
+            $newDecimalPart = '0';
+        }
+
+        if (!strlen(str_replace('0', '', $newDecimalPart))) {
+            $newDecimalPart = '0';
+        }
+
+        static::$remainder = null;
+        static::$decimal = null;
+
+        return $sign.$newWholePart.'.'.$newDecimalPart.$imaginary;
+    }
+
+    #[Pure]
+    private static function nonHalfEarlyReturn(int $digit): int
+    {
+        return $digit <=> 5;
+    }
+
+    private static function negativeReverser(): int
+    {
+        if (static::$decimal->isNegative()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+    private static function remainderCheck(): bool
+    {
+        $remainder = static::$remainder;
+
+        if (is_null($remainder)) {
+            return false;
+        }
+
+        $remainder = str_replace('0', '', $remainder);
+
+        return !empty($remainder);
+    }
+
+    private static function roundHalfUp(int $digit): int
+    {
+        $negative = self::negativeReverser();
+        $remainder = self::remainderCheck();
+
+        if ($negative) {
+            return $digit > 5 || ($digit == 5 && $remainder) ? 1 : 0;
+        } else {
+            return $digit > 4 ? 1 : 0;
+        }
+    }
+
+    private static function roundHalfDown(int $digit): int
+    {
+        $negative = self::negativeReverser();
+        $remainder = self::remainderCheck();
+
+        if ($negative) {
+            return $digit > 4 ? 1 : 0;
+        } else {
+            return $digit > 5 || ($digit == 5 && $remainder) ? 1 : 0;
+        }
+    }
+
+    private static function roundHalfEven(int $digit, int $nextDigit): int
+    {
+        $early = static::nonHalfEarlyReturn($digit);
+        $remainder = self::remainderCheck();
+
+        if ($early == 0) {
+            return ($nextDigit % 2 == 0 && !$remainder) ? 0 : 1;
+        } else {
+            return $early == 1 ? 1 : 0;
+        }
+    }
+
+    private static function roundHalfOdd(int $digit, int $nextDigit): int
+    {
+        $early = static::nonHalfEarlyReturn($digit);
+        $remainder = self::remainderCheck();
+
+        if ($early == 0) {
+            return ($nextDigit % 2 == 1 && !$remainder) ? 0 : 1;
+        } else {
+            return $early == 1 ? 1 : 0;
+        }
+    }
+
+    private static function roundHalfZero(int $digit): int
+    {
+        $remainder = self::remainderCheck();
+
+        return $digit > 5 || ($digit == 5 && $remainder) ? 1 : 0;
+    }
+
+    #[Pure]
+    private static function roundHalfInf(int $digit): int
+    {
+        return $digit > 4 ? 1 : 0;
+    }
+
+    #[Pure]
+    private static function roundCeil(int $digit): int
+    {
+        return $digit == 0 ? 0 : 1;
+    }
+
+    #[Pure]
+    private static function roundFloor(): int
+    {
+        return 0;
+    }
+
+    private static function roundRandom(int $digit): int
+    {
+        $early = static::nonHalfEarlyReturn($digit);
+        $remainder = self::remainderCheck();
+
+        if ($early == 0 && !$remainder) {
+            return RandomProvider::randomInt(0, 1, RandomProvider::MODE_SPEED)->asInt();
+        } else {
+            return (($early == 1 || $remainder) ? 1 : 0);
+        }
+    }
+
+    private static function roundAlternating(int $digit): int
+    {
+        $early = static::nonHalfEarlyReturn($digit);
+        $remainder = self::remainderCheck();
+
+        if ($early == 0 && !$remainder) {
+            $val = self::$alt;
+            self::$alt = (int)!$val;
+
+            return $val;
+        } else {
+            return (($early == 1 || $remainder) ? 1 : 0);
+        }
+    }
+
+    private static function roundStochastic(int $digit): int
+    {
+        $remainder = static::$remainder;
+
+        if (is_null($remainder)) {
+            $target = $digit;
+            $rangeMin = 0;
+            $rangeMax = 9;
+        } else {
+            $remainder = substr($remainder, 0, 3);
+            $target = (int)($digit.$remainder);
+            $rangeMin = 0;
+            $rangeMax = (int)str_repeat('9', strlen($remainder) + 1);
+        }
+
+        $random = RandomProvider::randomInt($rangeMin, $rangeMax, RandomProvider::MODE_SPEED)->asInt();
+
+        if ($random < $target) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+}

--- a/src/Samsara/Fermat/Types/Base/Interfaces/Numbers/DecimalInterface.php
+++ b/src/Samsara/Fermat/Types/Base/Interfaces/Numbers/DecimalInterface.php
@@ -102,7 +102,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function sin($scale = null, $round = true): DecimalInterface;
+    public function sin(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -110,7 +110,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function cos($scale = null, $round = true): DecimalInterface;
+    public function cos(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -118,7 +118,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function tan($scale = null, $round = true): DecimalInterface;
+    public function tan(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -126,7 +126,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function cot($scale = null, $round = true): DecimalInterface;
+    public function cot(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -134,7 +134,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function sec($scale = null, $round = true): DecimalInterface;
+    public function sec(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -142,7 +142,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function csc($scale = null, $round = true): DecimalInterface;
+    public function csc(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -150,7 +150,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arcsin($scale = null, $round = true): DecimalInterface;
+    public function arcsin(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -158,7 +158,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arccos($scale = null, $round = true): DecimalInterface;
+    public function arccos(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -166,7 +166,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arctan($scale = null, $round = true): DecimalInterface;
+    public function arctan(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -174,7 +174,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arccot($scale = null, $round = true): DecimalInterface;
+    public function arccot(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -182,7 +182,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arcsec($scale = null, $round = true): DecimalInterface;
+    public function arcsec(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -190,7 +190,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function arccsc($scale = null, $round = true): DecimalInterface;
+    public function arccsc(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -198,7 +198,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function sinh($scale = null, $round = true): DecimalInterface;
+    public function sinh(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -206,7 +206,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function cosh($scale = null, $round = true): DecimalInterface;
+    public function cosh(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -214,7 +214,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function tanh($scale = null, $round = true): DecimalInterface;
+    public function tanh(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -222,7 +222,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function coth($scale = null, $round = true): DecimalInterface;
+    public function coth(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -230,7 +230,7 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function sech($scale = null, $round = true): DecimalInterface;
+    public function sech(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
@@ -238,46 +238,46 @@ interface DecimalInterface extends SimpleNumberInterface
      *
      * @return DecimalInterface
      */
-    public function csch($scale = null, $round = true): DecimalInterface;
+    public function csch(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
      * @return DecimalInterface
      */
-    public function ln($scale = null): DecimalInterface;
+    public function ln(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
      * @return DecimalInterface
      */
-    public function log10($scale = null): DecimalInterface;
+    public function log10(int $scale = null, bool $round = true): DecimalInterface;
 
     /**
      * @param int|null $scale
      * @return DecimalInterface
      */
-    public function exp($scale = null): DecimalInterface;
+    public function exp(int $scale = null, bool $round = true): DecimalInterface;
+
+    /**
+     * @param int $decimals
+     * @param int|null $mode
+     * @return DecimalInterface
+     */
+    public function round(int $decimals = 0, ?int $mode = null): DecimalInterface;
 
     /**
      * @param int $decimals
      *
      * @return DecimalInterface
      */
-    public function round($decimals = 0): DecimalInterface;
+    public function truncate(int $decimals = 0): DecimalInterface;
 
     /**
-     * @param int $decimals
-     *
+     * @param int $scale
+     * @param int|null $mode
      * @return DecimalInterface
      */
-    public function truncate($decimals = 0): DecimalInterface;
-
-    /**
-     * @param $scale
-     *
-     * @return DecimalInterface
-     */
-    public function roundToScale($scale): DecimalInterface;
+    public function roundToScale(int $scale, ?int $mode = null): DecimalInterface;
 
     /**
      * @param $scale

--- a/src/Samsara/Fermat/Types/Decimal.php
+++ b/src/Samsara/Fermat/Types/Decimal.php
@@ -180,7 +180,7 @@ abstract class Decimal extends Number implements DecimalInterface, BaseConversio
         return $string;
     }
 
-    public function getValue($base = null): string // TODO: Check usages to see if it should be replaced with rawString()
+    public function getValue($base = null): string
     {
         if (is_null($base)) {
             $value = $this->convertObject();

--- a/src/Samsara/Fermat/Types/Fraction.php
+++ b/src/Samsara/Fermat/Types/Fraction.php
@@ -38,14 +38,22 @@ abstract class Fraction extends Number implements FractionInterface
     public function __construct($numerator, $denominator, int $base = 10)
     {
 
-        $numerator = Numbers::makeOrDont(Numbers::IMMUTABLE, $numerator, null, $base)->round();
-        $denominator = Numbers::makeOrDont(Numbers::IMMUTABLE, $denominator, null, $base)->round();
+        $numerator = Numbers::makeOrDont(Numbers::IMMUTABLE, $numerator, null, $base);
+        $denominator = Numbers::makeOrDont(Numbers::IMMUTABLE, $denominator, null, $base);
 
         if ($denominator->isEqual(0)) {
             throw new IntegrityConstraint(
                 'The denominator of a fraction cannot be zero.',
                 'Provide a denominator other than zero.',
                 'Cannot create new instance of Fraction with denominator of zero.'
+            );
+        }
+
+        if (!$numerator->isInt() || !$denominator->isInt()) {
+            throw new IntegrityConstraint(
+                'The numerator and denominator of a fraction must be whole numbers.',
+                'Only provide whole numbers to constructors of Fraction.',
+                'An attempt was made to create a fraction with non-integer components.'
             );
         }
 

--- a/src/Samsara/Fermat/Types/Traits/ComparisonTrait.php
+++ b/src/Samsara/Fermat/Types/Traits/ComparisonTrait.php
@@ -220,7 +220,7 @@ trait ComparisonTrait
 
         if ($check === 1) {
             $checkVal = $this->getDecimalPart();
-            $checkVal = trim($checkVal,'0');
+            $checkVal = str_replace('0', '', $checkVal);
 
             return !($checkVal !== '');
         }

--- a/src/Samsara/Fermat/Types/Traits/Decimal/InverseTrigonometryTrait.php
+++ b/src/Samsara/Fermat/Types/Traits/Decimal/InverseTrigonometryTrait.php
@@ -11,7 +11,7 @@ use Samsara\Fermat\Types\Base\Interfaces\Numbers\DecimalInterface;
 trait InverseTrigonometryTrait
 {
 
-    public function arcsin($scale = null, $round = true): DecimalInterface
+    public function arcsin(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -63,7 +63,7 @@ trait InverseTrigonometryTrait
 
     }
 
-    public function arccos($scale = null, $round = true): DecimalInterface
+    public function arccos(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -101,7 +101,7 @@ trait InverseTrigonometryTrait
 
     }
 
-    public function arctan($scale = null, $round = true): DecimalInterface
+    public function arctan(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -123,7 +123,7 @@ trait InverseTrigonometryTrait
 
     }
 
-    public function arccot($scale = null, $round = true): DecimalInterface
+    public function arccot(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -146,7 +146,7 @@ trait InverseTrigonometryTrait
 
     }
 
-    public function arcsec($scale = null, $round = true): DecimalInterface
+    public function arcsec(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -174,7 +174,7 @@ trait InverseTrigonometryTrait
 
     }
 
-    public function arccsc($scale = null, $round = true): DecimalInterface
+    public function arccsc(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -202,9 +202,9 @@ trait InverseTrigonometryTrait
 
     }
 
-    abstract public function roundToScale($scale): DecimalInterface;
+    abstract public function roundToScale(int $scale, ?int $mode = null): DecimalInterface;
 
-    abstract public function truncateToScale($scale): DecimalInterface;
+    abstract public function truncateToScale(int $scale): DecimalInterface;
 
     abstract public function getScale(): ?int;
 

--- a/src/Samsara/Fermat/Types/Traits/Decimal/LogTrait.php
+++ b/src/Samsara/Fermat/Types/Traits/Decimal/LogTrait.php
@@ -14,7 +14,7 @@ use Samsara\Fermat\Values\ImmutableDecimal;
 trait LogTrait
 {
 
-    public function exp($scale = null): DecimalInterface
+    public function exp(int $scale = null, bool $round = true): DecimalInterface
     {
         $scale = $scale ?? $this->getScale();
 
@@ -41,14 +41,13 @@ trait LogTrait
     }
 
     /**
-     * @param null $scale The number of digits which should be accurate
-     * @param bool $round Whether or not to round to the $scale value. If true, will round. If false, will truncate.
+     * @param int|null $scale The number of digits which should be accurate
      *
      * @return DecimalInterface
      * @throws IntegrityConstraint
      * @throws MissingPackage
      */
-    public function ln($scale = null, bool $round = true): DecimalInterface
+    public function ln(int $scale = null, bool $round = true): DecimalInterface
     {
         /*
         if ($this->isGreaterThanOrEqualTo(PHP_INT_MIN) && $this->isLessThanOrEqualTo(PHP_INT_MAX) && $scale <= 10) {
@@ -114,12 +113,11 @@ trait LogTrait
     }
 
     /**
-     * @param null $scale
-     * @param bool $round
+     * @param int|null $scale
      * @return mixed
      * @throws IntegrityConstraint|MissingPackage
      */
-    public function log10($scale = null, $round = true): DecimalInterface
+    public function log10(int $scale = null, bool $round = true): DecimalInterface
     {
         $log10 = Numbers::makeNaturalLog10();
 

--- a/src/Samsara/Fermat/Types/Traits/Decimal/TrigonometryTrait.php
+++ b/src/Samsara/Fermat/Types/Traits/Decimal/TrigonometryTrait.php
@@ -11,7 +11,7 @@ use Samsara\Fermat\Values\ImmutableDecimal;
 trait TrigonometryTrait
 {
 
-    public function sin($scale = null, $round = true): DecimalInterface
+    public function sin(int $scale = null, bool $round = true): DecimalInterface
     {
         if ($this->isEqual(0)) {
             return $this;
@@ -52,7 +52,7 @@ trait TrigonometryTrait
         }
     }
 
-    public function cos($scale = null, $round = true): DecimalInterface
+    public function cos(int $scale = null, bool $round = true): DecimalInterface
     {
         if ($this->isEqual(0)) {
             return $this->setValue('1');
@@ -95,7 +95,7 @@ trait TrigonometryTrait
         }
     }
 
-    public function tan($scale = null, $round = true): DecimalInterface
+    public function tan(int $scale = null, bool $round = true): DecimalInterface
     {
         $scale = $scale ?? $this->getScale();
 
@@ -189,7 +189,7 @@ trait TrigonometryTrait
 
     }
 
-    public function cot($scale = null, $round = true): DecimalInterface
+    public function cot(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $pi = Numbers::makePi();
@@ -230,7 +230,7 @@ trait TrigonometryTrait
 
     }
 
-    public function sec($scale = null, $round = true): DecimalInterface
+    public function sec(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $one = Numbers::makeOne();
@@ -257,7 +257,7 @@ trait TrigonometryTrait
 
     }
 
-    public function csc($scale = null, $round = true): DecimalInterface
+    public function csc(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $one = Numbers::makeOne();
@@ -284,7 +284,7 @@ trait TrigonometryTrait
 
     }
 
-    public function sinh($scale = null, $round = true): DecimalInterface
+    public function sinh(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $two = Numbers::make(Numbers::IMMUTABLE, 2);
@@ -307,7 +307,7 @@ trait TrigonometryTrait
 
     }
 
-    public function cosh($scale = null, $round = true): DecimalInterface
+    public function cosh(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $two = Numbers::make(Numbers::IMMUTABLE, 2);
@@ -330,7 +330,7 @@ trait TrigonometryTrait
 
     }
 
-    public function tanh($scale = null, $round = true): DecimalInterface
+    public function tanh(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -349,7 +349,7 @@ trait TrigonometryTrait
 
     }
 
-    public function coth($scale = null, $round = true): DecimalInterface
+    public function coth(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -368,7 +368,7 @@ trait TrigonometryTrait
 
     }
 
-    public function sech($scale = null, $round = true): DecimalInterface
+    public function sech(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();
@@ -388,7 +388,7 @@ trait TrigonometryTrait
 
     }
 
-    public function csch($scale = null, $round = true): DecimalInterface
+    public function csch(int $scale = null, bool $round = true): DecimalInterface
     {
 
         $scale = $scale ?? $this->getScale();

--- a/tests/Samsara/Fermat/NumbersTest.php
+++ b/tests/Samsara/Fermat/NumbersTest.php
@@ -56,13 +56,26 @@ class NumbersTest extends TestCase
 
         $this->assertEquals('1.1', $one->getValue());
 
-        $one = Numbers::make(Numbers::IMMUTABLE_FRACTION, 1.1);
+    }
+    /**
+     * @medium
+     */
+    public function testMakeFromFloatExceptions1()
+    {
 
-        $this->assertEquals('1/1', $one->getValue());
+        $this->expectException(IntegrityConstraint::class);
 
-        $one = Numbers::make(Numbers::MUTABLE_FRACTION, 1.1);
+        Numbers::make(Numbers::MUTABLE_FRACTION, 1.1);
 
-        $this->assertEquals('1/1', $one->getValue());
+    }/**
+ * @medium
+ */
+    public function testMakeFromFloatExceptions2()
+    {
+
+        $this->expectException(IntegrityConstraint::class);
+
+        Numbers::make(Numbers::IMMUTABLE_FRACTION, 1.1);
 
     }
     /**
@@ -79,13 +92,26 @@ class NumbersTest extends TestCase
 
         $this->assertEquals('1.3', $one->getValue());
 
-        $one = Numbers::make(Numbers::IMMUTABLE_FRACTION, '1.3');
+    }
+    /**
+     * @medium
+     */
+    public function testMakeFromStringExceptions1()
+    {
 
-        $this->assertEquals('1/1', $one->getValue());
+        $this->expectException(IntegrityConstraint::class);
 
-        $one = Numbers::make(Numbers::MUTABLE_FRACTION, '1.3');
+        Numbers::make(Numbers::MUTABLE_FRACTION, '1.1');
 
-        $this->assertEquals('1/1', $one->getValue());
+    }/**
+ * @medium
+ */
+    public function testMakeFromStringExceptions2()
+    {
+
+        $this->expectException(IntegrityConstraint::class);
+
+        Numbers::make(Numbers::IMMUTABLE_FRACTION, '1.1');
 
     }
     /**

--- a/tests/Samsara/Fermat/Provider/RoundingProviderTest.php
+++ b/tests/Samsara/Fermat/Provider/RoundingProviderTest.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace Samsara\Fermat\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Samsara\Fermat\Types\Decimal;
+use Samsara\Fermat\Values\ImmutableDecimal;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class RoundingProviderTest extends TestCase
+{
+
+    public function testRandomDefault()
+    {
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_EVEN, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52222', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52222', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfUp()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_HALF_UP);
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_UP, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52223', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52222', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfDown()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_HALF_DOWN);
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_DOWN, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52222', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52223', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfOdd()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_HALF_ODD);
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_ODD, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52223', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52223', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfZero()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_HALF_ZERO);
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_ZERO, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52222', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55555', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-2.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52222', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfInf()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_HALF_INF);
+
+        $num1 = new ImmutableDecimal('1.111111');
+        $num2 = new ImmutableDecimal('1.555555');
+        $num3 = new ImmutableDecimal('555555');
+        $num4 = new ImmutableDecimal('9999.9999');
+        $num5 = new ImmutableDecimal('2.222222');
+        $num6 = new ImmutableDecimal('2.522225');
+
+        $this->assertEquals(RoundingProvider::MODE_HALF_INF, RoundingProvider::getRoundingMode());
+        $this->assertEquals('1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('2.0', RoundingProvider::round($num2));
+        $this->assertEquals('556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('3.0', RoundingProvider::round($num6));
+        $this->assertEquals('3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('2.52223', RoundingProvider::round($num6, 5));
+
+        $num1 = new ImmutableDecimal('-1.111111');
+        $num2 = new ImmutableDecimal('-1.555555');
+        $num3 = new ImmutableDecimal('-555555');
+        $num4 = new ImmutableDecimal('-9999.9999');
+        $num5 = new ImmutableDecimal('-2.222222');
+        $num6 = new ImmutableDecimal('-2.522225');
+
+        $this->assertEquals('-1.11111', RoundingProvider::round($num1, 5));
+        $this->assertEquals('-1.55556', RoundingProvider::round($num2, 5));
+        $this->assertEquals('-2.0', RoundingProvider::round($num2));
+        $this->assertEquals('-556000.0', RoundingProvider::round($num3, -3));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4));
+        $this->assertEquals('-10000.0', RoundingProvider::round($num4, 3));
+        $this->assertEquals('-2.22', RoundingProvider::round($num5, 2));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6));
+        $this->assertEquals('-3.0', RoundingProvider::round($num6->truncateToScale(1)));
+        $this->assertEquals('-2.52223', RoundingProvider::round($num6, 5));
+
+    }
+
+    public function testRoundHalfRandom()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_RANDOM);
+
+        $num1 = new ImmutableDecimal('1.5');
+
+        $this->assertEquals(RoundingProvider::MODE_RANDOM, RoundingProvider::getRoundingMode());
+        for ($i=0;$i<20;$i++) {
+            $this->assertEqualsWithDelta(1.5, RoundingProvider::round($num1), 0.5);
+        }
+
+        $num1 = new ImmutableDecimal('-1.5');
+
+        for ($i=0;$i<20;$i++) {
+            $this->assertEqualsWithDelta(-1.5, RoundingProvider::round($num1), 0.5);
+        }
+
+    }
+
+    public function testRoundHalfAlternating()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_ALTERNATING);
+
+        $num1 = new ImmutableDecimal('1.5');
+
+        $this->assertEquals(RoundingProvider::MODE_ALTERNATING, RoundingProvider::getRoundingMode());
+        $sum = 0;
+        for ($i=0;$i<20;$i++) {
+            $result = (int)RoundingProvider::round($num1);
+            $this->assertEqualsWithDelta(1.5, $result, 0.5);
+            $sum += $result;
+        }
+
+        $this->assertEquals(30, $sum);
+
+        $num1 = new ImmutableDecimal('-1.5');
+
+        $sum = 0;
+        for ($i=0;$i<20;$i++) {
+            $result = (int)RoundingProvider::round($num1);
+            $this->assertEqualsWithDelta(-1.5, $result, 0.5);
+            $sum += $result;
+        }
+
+        $this->assertEquals(-30, $sum);
+
+    }
+
+    public function testRoundHalfStochastic()
+    {
+
+        RoundingProvider::setRoundingMode(RoundingProvider::MODE_STOCHASTIC);
+
+        $num1 = new ImmutableDecimal('1.5');
+
+        $this->assertEquals(RoundingProvider::MODE_STOCHASTIC, RoundingProvider::getRoundingMode());
+        $sum = 0;
+        for ($i=0;$i<20;$i++) {
+            $result = (int)RoundingProvider::round($num1);
+            $this->assertEqualsWithDelta(1.5, $result, 0.5);
+            $sum += $result;
+        }
+
+        $this->assertEqualsWithDelta(30, $sum, 10);
+
+        $num1 = new ImmutableDecimal('-1.5');
+
+        $sum = 0;
+        for ($i=0;$i<20;$i++) {
+            $result = (int)RoundingProvider::round($num1);
+            $this->assertEqualsWithDelta(-1.5, $result, 0.5);
+            $sum += $result;
+        }
+
+        $this->assertEqualsWithDelta(-30, $sum, 10);
+
+    }
+
+}

--- a/tests/Samsara/Fermat/Values/ImmutableDecimalTest.php
+++ b/tests/Samsara/Fermat/Values/ImmutableDecimalTest.php
@@ -860,11 +860,13 @@ class ImmutableDecimalTest extends TestCase
 
         $this->assertEquals('5', $negFive->abs()->getValue());
         $this->assertEquals('5', $negFive->absValue());
+        $this->assertEquals('-5', $negFive->getValue());
 
         $five = new ImmutableDecimal(5);
 
         $this->assertEquals('5', $five->abs()->getValue());
         $this->assertEquals('5', $five->absValue());
+        $this->assertEquals('5', $five->getValue());
 
     }
     /**
@@ -953,7 +955,7 @@ class ImmutableDecimalTest extends TestCase
 
         $pointFive = new ImmutableDecimal('0.5');
 
-        $this->assertEquals('1', $pointFive->round()->getValue());
+        $this->assertEquals('0', $pointFive->round()->getValue());
 
         $pointOneFive = new ImmutableDecimal('0.15');
 

--- a/tests/Samsara/Fermat/Values/ImmutableFractionTest.php
+++ b/tests/Samsara/Fermat/Values/ImmutableFractionTest.php
@@ -51,8 +51,8 @@ class ImmutableFractionTest extends TestCase
 
         $negOneHalf = new ImmutableFraction(new ImmutableDecimal('-1'), new ImmutableDecimal('2'));
 
-        $this->assertEquals('1/2', $negOneHalf->absValue());
         $this->assertEquals('-1/2', $negOneHalf->getValue());
+        $this->assertEquals('1/2', $negOneHalf->absValue());
         $this->assertEquals('1/2', $negOneHalf->abs()->getValue());
 
         $oneHalf = new ImmutableFraction(new ImmutableDecimal(1), new ImmutableDecimal(2));


### PR DESCRIPTION
### Added

- `RoundingProvider`
  - Rounding Modes:
    - `const MODE_HALF_UP = 1`
    - `const MODE_HALF_DOWN = 2`
    - `const MODE_HALF_EVEN = 3`
    - `const MODE_HALF_ODD = 4`
    - `const MODE_HALF_ZERO = 5`
    - `const MODE_HALF_INF = 6`
    - `const MODE_CEIL = 7`
    - `const MODE_FLOOR = 8`
    - `const MODE_RANDOM = 9`
    - `const MODE_ALTERNATING = 10`
    - `const MODE_STOCHASTIC = 11`
  - Public Methods:
    - `round(DecimalInterface $decimal, int $places = 0): string`
    - `setRoundingMode(int $mode): void`
    - `getRoundingMode(): int`

### Changed

- `Decimal` via `ScaleTrait`
  - The `round()` method now takes a new optional parameter `$mode` and utilizes the rounding provider.
  - The `roundToScale()` method now takes a new optional parameter `$mode` and utilitizes the rounding provider
- `Fraction`
  - Removed implicit round of decimal values in constructor. Attempting to create a fraction with non-integer values will now throw an `IntegrityConstraintException`
- `DecimalInterface`
  - Updated signature for `round()` and `roundToScale()`
  - Since I was in the file anyway, updated other signatures for missing PHP 8 parameter types (and associated implementations), as detailed in #96